### PR TITLE
Postgres deployable POC

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "dependencies": {
     "axios": "^0.19.0",
-    "pg": "^8.7.1",
-    "pg-native": "^3.0.0",
+    "postgres": "^1.0.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "^3.0.1",

--- a/src/server/add-post.js
+++ b/src/server/add-post.js
@@ -1,21 +1,14 @@
-import { Pool } from 'pg';
+import postgres from './config/postgres';
 
 export async function handler(req) {
   //
   // Get params
-  const { title, content } = JSON.parse(req.body);
-
-  // Connect to database
-  const ssl = { rejectUnauthorized: false };
-  const connectionString = process.env.DATABASE_URL;
-  const database = new Pool({ connectionString, ssl });
+  const record = JSON.parse(req.body);
+  const database = postgres();
 
   try {
     // Add a new post
-    await database.query(
-      `insert into posts (title, content, date) values ($1, $2, now())`,
-      [title, content]
-    );
+    await database`insert into posts ${database(record, 'title', 'content')}`;
 
     // End the connection and return a success (200) response
     await database.end();

--- a/src/server/config/postgres.js
+++ b/src/server/config/postgres.js
@@ -1,0 +1,7 @@
+import postgres from 'postgres';
+
+export default function () {
+  const ssl = { rejectUnauthorized: false };
+  const connectionString = process.env.DATABASE_URL;
+  return postgres(connectionString, { ssl });
+}

--- a/src/server/get-posts.js
+++ b/src/server/get-posts.js
@@ -1,4 +1,4 @@
-import { Pool } from 'pg';
+import postgres from './config/postgres';
 import generateDB from './config/generateDB';
 
 export async function handler(req) {
@@ -13,20 +13,13 @@ export async function handler(req) {
     };
   }
 
-  // Connect to the database
-  const ssl = { rejectUnauthorized: false };
-  const connectionString = process.env.DATABASE_URL;
-  const database = new Pool({ connectionString, ssl });
-
+  const database = postgres();
   try {
     // Fetch all posts
-    const result = await database.query(
-      'SELECT * FROM posts ORDER BY date desc;'
-    );
-
-    // Close the connection and return the result
+    const posts = await database`
+      SELECT * FROM posts ORDER BY date desc;`;
     await database.end();
-    return { statusCode: 200, body: JSON.stringify({ posts: result.rows }) };
+    return { statusCode: 200, body: JSON.stringify({ posts }) };
 
     // If there is no table, create one with some mock data
   } catch (err) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8864,6 +8864,11 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
+postgres@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/postgres/-/postgres-1.0.2.tgz#7b9f6769934f727cec0f1d7ef58d4915a327f5dd"
+  integrity sha512-zeLgt42KSUNgX/uvo+gbVxTAYwgSY6MIKuU/a8YWuObX4rtGuKrVWopvEAqIAPSO0FeHS1TsSKnqPjoufPy8NA==
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"


### PR DESCRIPTION
This is an example of how to make posgres deployable to serverless.

It swaps the `pg` library with the `postgres` library (with zero dependencies). The query syntax is a little unusual (but arguably simpler to understand).

I have only converted the get-posts and add-post functions, delete and generateDB will still break in this draft PR.
